### PR TITLE
fix: role name bug

### DIFF
--- a/terragrunt/iam.tf
+++ b/terragrunt/iam.tf
@@ -1,5 +1,5 @@
 locals {
-  salesforce_backup_role_name = "salesforce-backup-oidc"
+  salesforce_backup_role_name = "salesforce-backup"
 }
 
 module "oidc" {
@@ -11,7 +11,7 @@ module "oidc" {
 
   roles = [
     {
-      name      = "salesforce-backup"
+      name      = local.salesforce_backup_role_name
       repo_name = "salesforce_backup"
       claim     = "ref:refs/heads/main"
     }


### PR DESCRIPTION
# Summary | Résumé

The role name we are trying to attach the policy to doesn't match the
name we gave the OIDC role for backing up salesforce data this
reconciles it so they match.


