### PR TITLE
feat: Enable S3 replication

### DIFF
--- a/.github/workflows/salesforce-backup.yml
+++ b/.github/workflows/salesforce-backup.yml
@@ -49,4 +49,4 @@ jobs:
 
     - name: Upload to S3 bucket
       run: |
-        aws s3 sync ./csv s3://cds-salesforce-backups
+        aws s3 sync ./csv s3://cds-salesforce-backups/bes/crm/salesforce/

--- a/terragrunt/iam.tf
+++ b/terragrunt/iam.tf
@@ -56,11 +56,13 @@ resource "aws_iam_role" "salesforce_replicate" {
   assume_role_policy = data.aws_iam_policy_document.salesforce_replicate_assume.json
   tags               = local.common_tags
 }
+
 resource "aws_iam_policy" "salesforce_replicate" {
   name   = "SalesforceReplicateToDataLake"
   policy = data.aws_iam_policy_document.salesforce_replicate_assume.json
   tags   = local.common_tags
 }
+
 resource "aws_iam_role_policy_attachment" "salesforce_replicate" {
   role       = aws_iam_role.salesforce_replicate.name
   policy_arn = aws_iam_policy.salesforce_replicate.arn
@@ -108,7 +110,7 @@ data "aws_iam_policy_document" "salesforce_replicate" {
       "s3:ReplicateDelete"
     ]
     resources = [
-      "${local.data_lake_raw_s3_bucket_arn}/*"
+      "${local.data_lake_raw_s3_bucket_arn}/bes/crm/salesforce/*"
     ]
   }
 }

--- a/terragrunt/locals.tf
+++ b/terragrunt/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  common_tags = {
+    CostCentre = var.billing_code
+    Terraform  = "true"
+  }
+  data_lake_raw_s3_bucket_arn  = "arn:aws:s3:::${local.data_lake_raw_s3_bucket_name}"
+  data_lake_raw_s3_bucket_name = "cds-data-lake-raw-production"
+}

--- a/terragrunt/s3.tf
+++ b/terragrunt/s3.tf
@@ -1,6 +1,6 @@
 module "cds_salesforce_backups_bucket" {
   source = "github.com/cds-snc/terraform-modules//S3?ref=v5.1.11"
-  
+
   replication_configuration = {
     role = aws_iam_role.salesforce_replicate.arn
 

--- a/terragrunt/s3.tf
+++ b/terragrunt/s3.tf
@@ -1,5 +1,18 @@
 module "cds_salesforce_backups_bucket" {
   source = "github.com/cds-snc/terraform-modules//S3?ref=v5.1.11"
+  replication_configuration = {
+    role = aws_iam_role.salesforce_replicate.arn
+
+    rules = [
+      {
+        id       = "send-to-data-lake"
+        priority = 10
+        destination = {
+          bucket = local.data_lake_raw_s3_bucket_arn
+        }
+      }
+    ]
+  }
 
   bucket_name        = "cds-salesforce-backups"
   billing_tag_value  = var.billing_code

--- a/terragrunt/s3.tf
+++ b/terragrunt/s3.tf
@@ -1,5 +1,6 @@
 module "cds_salesforce_backups_bucket" {
   source = "github.com/cds-snc/terraform-modules//S3?ref=v5.1.11"
+  
   replication_configuration = {
     role = aws_iam_role.salesforce_replicate.arn
 


### PR DESCRIPTION
# Summary | Résumé

Copy the Salesforce backup files to the Platform Data Lake. The raw files will be purged daily once the data is moved to the transformed bucket.

